### PR TITLE
increase binderbot timeout

### DIFF
--- a/.github/workflows/binderbot.yaml
+++ b/.github/workflows/binderbot.yaml
@@ -56,6 +56,7 @@ jobs:
           --binder-url ${{ steps.parse.outputs.binder_url }} \
           --repo ${{ steps.parse.outputs.binder_repo }} \
           --ref ${{ steps.parse.outputs.binder_ref }} \
+          --nb-timeout 1200 # 20 minutes enough? \
           *.ipynb
       - name: Commit files
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
Together with https://github.com/pangeo-gallery/binderbot/pull/9, this should increase the timeout to 20 minutes per notebook. Is that enough?