### PR TITLE
Removing custom kernel from notebook metadata

### DIFF
--- a/06_Bathy_Explorer.ipynb
+++ b/06_Bathy_Explorer.ipynb
@@ -15,26 +15,14 @@
    "source": [
     "import xarray as xr\n",
     "import hvplot.xarray\n",
-    "import fsspec\n",
-    "from dask.distributed import Client\n",
     "import geoviews as gv"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ds = xr.open_zarr(fsspec.get_mapper('s3://esip-qhub/noaa/bathy/etopo1_bed_g2', \n",
-    "                                   requester_pays=True), consolidated=True)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### North America subset"
+    "### Open ETOPO1 data via OPeNDAP"
    ]
   },
   {
@@ -43,7 +31,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "na = ds.topo.sel(lon=slice(-130,-50),lat=slice(15,50))"
+    "ds = xr.open_dataset('http://geoport.usgs.esipfed.org/thredds/dodsC/bathy/etopo1_bed_g2')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Extract the lon/lat range we want"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "na = ds.topo.sel(lon=slice(-130,-50),lat=slice(15,50))   # North America"
    ]
   },
   {
@@ -67,7 +71,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Visualize with [Holoviz](holoviz.org) tools"
+    "### Visualize with [Holoviz](holoviz.org) tools"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create color-shaded quadmesh "
    ]
   },
   {
@@ -77,6 +88,13 @@
    "outputs": [],
    "source": [
     "bathy_grid = na.hvplot.quadmesh(x='lon', y='lat', rasterize=True, geo=True, cmap='viridis')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create black contour lines"
    ]
   },
   {
@@ -92,7 +110,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Overlay bathy color-shaded grid, contours and ESRI tiles as basemap"
+    "Overlay color-shaded mesh, contours and ESRI basemap "
    ]
   },
   {
@@ -101,15 +119,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "(bathy_grid * contours) * gv.tile_sources.ESRI"
+    "(bathy_grid * contours) * gv.tile_sources.ESRI    "
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:pangeo]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-pangeo-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
binderbot want to see  python 3 kernel specified, not some custom kernel:
```
 "metadata": {
  "kernelspec": {
   "display_name": "Python 3",
   "language": "python",
   "name": "python3"
  }
```